### PR TITLE
Fix 3C test that fails only on Windows.

### DIFF
--- a/clang/test/3C/multiple_tu.c
+++ b/clang/test/3C/multiple_tu.c
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: mkdir %t && cd %t
-// RUN: python -c 'import sys, json; json.dump([{"arguments": ["clang", "-c", "%s"], "directory": "%S", "file": "%s"}]*2, sys.stdout)' > compile_commands.json
+// RUN: python -c 'import sys, json; json.dump([{"arguments": ["clang", "-c", r"%s"], "directory": r"%S", "file": r"%s"}]*2, sys.stdout)' > compile_commands.json
 // RUN: 3c -dump-stats -p %t -base-dir=%S %s | FileCheck -match-full-lines %s
 // RUN: python -c 'import sys, json; exit(any(e["Name"].startswith("ImplicitCastExpr") for e in json.load(sys.stdin)["RootCauseStats"]))' < PerWildPtrStats.json
 


### PR DESCRIPTION
The test 3C/multiple_tu.c fails only on Windows. The problem is the test script. The script generates a command file in JSON format by piping a small generated Python program into the Python interpreter.  The program contains strings for file names.
On Windows, the directory separator is a backslash character (`\`). The backslash is interpreted as a string escape character. This results in JSON with incorrect paths. Use raw Python strings for the file names so that Python leaves them alone.