### PR TITLE
Fix for Issue #1195

### DIFF
--- a/clang/lib/Analysis/CFG.cpp
+++ b/clang/lib/Analysis/CFG.cpp
@@ -5965,6 +5965,10 @@ const Expr *CFGBlock::getLastCondition() const {
   if (isa<ObjCForCollectionStmt>(Cond) || isa<DeclStmt>(Cond))
     return nullptr;
 
+  // Introduced as a fix for crash --> #1195
+  if (!isa<Expr>(Cond))
+    return nullptr;
+
   // Only ObjCForCollectionStmt is known not to be a non-Expr terminator, hence
   // the cast<>.
   return cast<Expr>(Cond)->IgnoreParens();


### PR DESCRIPTION
**Reason for the error -->** 
typename llvm::cast_retty<X, Y*>::ret_type llvm::cast(Y*) [with X = clang::Expr; Y = const clang::Stmt; typename llvm::cast_retty<X, Y*>::ret_type = const clang::Expr*]: Assertion `isa<X>(Val) && "cast<Ty>() argument of incompatible type!"' failed.

**Description of Fix -->** 
I have a fix I believe involves the least changes, so as to disturb the main line as little as possible.

**Regression CheckedC Testing -->** 
Testing Time: 14.53s
  Unsupported:  3
  Passed     : 96

**Regression Clang Testing -->**
Failed Tests (3):
  Clang :: 3C/json_formatting.c
  Clang :: 3C/json_formatting_backslash.c
  Clang :: 3C/multiple_tu.c


Testing Time: 2095.93s
  Unsupported      :    75
  Passed           : 27663
  Expectedly Failed:    34
  Failed           :     3


Please note that the above 3 tests are also failing for me on "untouched" main-branch.
