### PR TITLE
Update 3C test that fails on Windows.

### DIFF
--- a/clang/test/3C/dont_rewrite_cflags.c
+++ b/clang/test/3C/dont_rewrite_cflags.c
@@ -6,5 +6,5 @@
 
 // RUN: 3c -base-dir=%S %s -- -O2 -D_FORTIFY_SOURCE=2
 
-#include <sys/socket.h>
+#include <string.h>
 


### PR DESCRIPTION
This updates a 3C test that was including a single system header file that does not exist on Windows.   There wasn't a lot of context about the test, so I'm not sure whether the specific system header file matters.